### PR TITLE
Fix docker connection in quick start example

### DIFF
--- a/quick-start/config.yaml
+++ b/quick-start/config.yaml
@@ -11,4 +11,5 @@ configserver:
   url: "http://authconfig:8080/config"
 backend: docker
 docker:
-  host: unix:///var/run/docker.sock
+  connection:
+    host: unix:///var/run/docker.sock


### PR DESCRIPTION
Currently the main container is crashing with the following error:
```
{"timestamp":"2021-10-15T19:26:55Z","level":"crit","code":"CORE_CONFIG_ERROR","message":"Invalid configuration in file /etc/containerssh/config.yaml (failed to read configuration file /etc/containerssh/config.yaml (yaml: unmarshal errors:\n  line 14: field host not found in type docker.Config))","details":{"module":"core"}}
```
According to the [docs](https://containerssh.io/reference/docker/#securing-the-docker-socket), docker endpoint needs to be speficied under the docker.connection.host yaml path.

---
name: Example
about: Adding or fixin an example
title: ''
assignees: janoszen
---

## Please give a brief description of the change

...

## Are you the owner of the code or do you have permission of the owner?

...

## The code will be published under the MIT-0 license. Have you read and understood this license?

...
