### PR TITLE
Update quickstart image version

### DIFF
--- a/quick-start/docker-compose.yaml
+++ b/quick-start/docker-compose.yaml
@@ -4,10 +4,10 @@
 # Please see the ContainerSSH reference manual for a detailed guide:
 # https://containerssh.io/reference/
 ---
-version: '3.2'
+version: '3'
 services:
   containerssh:
-    image: containerssh/containerssh:0.4.1
+    image: containerssh/containerssh:v0.5.0
     ports:
         # For security we only allow this demo to run on localhost.
       - 127.0.0.1:2222:2222
@@ -39,4 +39,4 @@ services:
     user: "root"
   authconfig:
     # The test-authconfig server lets in the "foo" user with the "bar" password.
-    image: containerssh/containerssh-test-authconfig:0.4.1
+    image: containerssh/containerssh-test-authconfig:v0.5.0

--- a/quick-start/kubernetes.yaml
+++ b/quick-start/kubernetes.yaml
@@ -141,7 +141,7 @@ spec:
       containers:
         # Run ContainerSSH
         - name: containerssh
-          image: containerssh/containerssh:0.4
+          image: containerssh/containerssh:v0.5.0
           securityContext:
             # Read only container
             readOnlyRootFilesystem: true
@@ -160,7 +160,7 @@ spec:
               readOnly: true
         # Run the auth-config test server for authentication
         - name: containerssh-authconfig
-          image: containerssh/containerssh-test-authconfig:0.4
+          image: containerssh/containerssh-test-authconfig:v0.5.0
           securityContext:
             readOnlyRootFilesystem: true
       # Don't allow containers running as root (ContainerSSH doesn't need it)


### PR DESCRIPTION
containerssh releases v0.5.0 - jan 7, 2024
(https://github.com/ContainerSSH/ContainerSSH/releases/tag/v0.5.0)

update quickstart
docker yaml update / 0.4.1 -> v0.5.0
kubernetes yaml update / 0.4 -> v0.5.0

## Please give a brief description of the change
quickstart example yaml file edit docker image version for releases v0.5.0

![image](https://github.com/ContainerSSH/examples/assets/51896679/06df9fb8-5446-42ab-a9e5-94fe42541ae8)
...

## Are you the owner of the code or do you have permission of the owner?
yes
...

## The code will be published under the MIT-0 license. Have you read and understood this license?
yes
...
