### PR TITLE
fix: remove version from the docker compose file

### DIFF
--- a/quick-start/docker-compose.yaml
+++ b/quick-start/docker-compose.yaml
@@ -4,7 +4,6 @@
 # Please see the ContainerSSH reference manual for a detailed guide:
 # https://containerssh.io/reference/
 ---
-version: '3.2'
 services:
   containerssh:
     image: containerssh/containerssh:0.4.1


### PR DESCRIPTION
---
name: remove `version` from docker compose 
assignees: janoszen
---

## Please give a brief description of the change
`version` in docker compose is deprecated and should be removed 
https://forums.docker.com/t/do-you-need-to-put-the-version-at-the-top-of-docker-compose-yml-file/135863


## Are you the owner of the code or do you have permission of the owner?

I don't think so 

## The code will be published under the MIT-0 license. Have you read and understood this license?

yes
